### PR TITLE
feat: Revamp front page with new hero, categories, and card styles

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -14,22 +14,140 @@ get_header();
 
 	<div class="container mx-auto px-4 py-12">
 
-		<div class="text-center py-12">
-			<h1 class="text-4xl font-bold text-gray-800 mb-4">She Cy Marketplace</h1>
-			<p class="text-lg text-gray-600 mb-8">Discover unique items from our community</p>
-			<form role="search" method="get" class="search-form relative max-w-lg mx-auto" action="<?php echo esc_url( home_url( '/' ) ); ?>">
-				<label class="w-full">
-					<span class="screen-reader-text">Search for:</span>
-					<input type="search" class="search-field w-full py-4 pl-6 pr-16 rounded-full border-2 border-gray-200 focus:outline-none focus:border-violet-500 transition-colors" placeholder="Search products..." value="<?php echo get_search_query(); ?>" name="s" />
-				</label>
-				<button type="submit" class="search-submit absolute top-0 right-0 h-full px-6 text-gray-600 hover:text-violet-600">
-					<svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-					</svg>
-				</button>
-				<input type="hidden" name="post_type" value="shecy_product" />
-			</form>
-		</div>
+		<div class="relative bg-gradient-to-r from-sky-500 to-indigo-500">
+    <div class="absolute inset-0">
+        <img class="object-cover w-full h-full" src="<?php echo get_template_directory_uri(); ?>/assets/images/hero-placeholder.jpg" alt="Hero background">
+        <div class="absolute inset-0 bg-gray-900 bg-opacity-50"></div>
+    </div>
+    <div class="relative px-4 py-24 mx-auto sm:px-6 lg:px-8 max-w-7xl">
+        <div class="max-w-lg mx-auto text-center">
+            <h1 class="text-3xl font-bold text-white sm:text-4xl lg:text-5xl">
+                Find your next favorite thing
+            </h1>
+            <p class="mt-4 text-base font-normal text-gray-200 sm:text-lg">
+                A community-driven marketplace for unique and handcrafted items.
+            </p>
+            <form role="search" method="get" class="search-form mt-8 sm:flex sm:justify-center" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+                <label class="w-full sm:w-auto">
+                    <span class="screen-reader-text">Search for:</span>
+                    <input type="search" class="search-field w-full px-5 py-4 text-base text-gray-900 placeholder-gray-500 bg-white border border-transparent rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-white" placeholder="Search products..." value="<?php echo get_search_query(); ?>" name="s">
+                </label>
+                <button type="submit" class="search-submit inline-flex items-center justify-center w-full sm:w-auto px-5 py-4 mt-4 sm:mt-0 sm:ml-4 text-base font-semibold text-white bg-indigo-600 border border-transparent rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-indigo-500">
+                    Search
+                </button>
+								<input type="hidden" name="post_type" value="shecy_product" />
+            </form>
+        </div>
+    </div>
+</div>
+
+<section class="py-12 sm:py-16 lg:py-20 bg-gray-50">
+      <div class="px-4 mx-auto sm:px-6 lg:px-8 max-w-7xl">
+        <div class="flex items-center justify-center text-center md:justify-between sm:text-left">
+          <div>
+            <h2 class="text-2xl font-bold text-gray-900 sm:text-3xl">
+              Popular Categories
+            </h2>
+            <p class="text-base text-gray-600 font-normal mt-2.5">
+              Choose from wide variety of items
+            </p>
+          </div>
+
+          <div class="hidden md:block">
+            <a href="#" title="" class="inline-flex items-center p-1 -m-1 text-xs font-bold tracking-wide text-gray-400 uppercase transition-all duration-200 rounded hover:text-gray-900 focus:ring-2 focus:text-gray-900 focus:ring-gray-900 focus:ring-offset-2 focus:outline-none" role="button">
+              All Categories
+              <svg class="w-4 h-4 ml-1.5 -mt-0.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+              </svg>
+            </a>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-2 gap-5 mt-8 text-center sm:mt-12 sm:grid-cols-3 xl:grid-cols-6 sm:gap-6">
+          <div class="relative transition-all duration-300 bg-gray-100 rounded-xl hover:shadow-xl hover:bg-white">
+            <div class="px-4 py-5 sm:p-6">
+              <img class="object-cover w-24 h-24 mx-auto border border-gray-200 rounded-full" src="https://cdn.rareblocks.xyz/collection/clarity-ecommerce/images/categories/2/smart-watches.png" alt="">
+
+              <p class="mt-5 text-base font-bold text-gray-900">
+                <a href="#" title="">
+                  Smart <br class="block sm:hidden xl:block">Watches
+                  <span class="absolute inset-0" aria-hidden="true"></span>
+                </a>
+              </p>
+            </div>
+          </div>
+
+          <div class="relative transition-all duration-300 bg-gray-100 rounded-xl hover:shadow-xl hover:bg-white">
+            <div class="px-4 py-5 sm:p-6">
+              <img class="object-cover w-24 h-24 mx-auto border border-gray-200 rounded-full" src="https://cdn.rareblocks.xyz/collection/clarity-ecommerce/images/categories/2/wireless-earphone.png" alt="">
+              <p class="mt-5 text-base font-bold text-gray-900">
+                <a href="#" title="">
+                  True Wireless Earphone
+                  <span class="absolute inset-0" aria-hidden="true"></span>
+                </a>
+              </p>
+            </div>
+          </div>
+
+          <div class="relative transition-all duration-300 bg-gray-100 rounded-xl hover:shadow-xl hover:bg-white">
+            <div class="px-4 py-5 sm:p-6">
+              <img class="object-cover w-24 h-24 mx-auto border border-gray-200 rounded-full" src="https://cdn.rareblocks.xyz/collection/clarity-ecommerce/images/categories/2/wireless-headphone.png" alt="">
+              <p class="mt-5 text-base font-bold text-gray-900">
+                <a href="#" title="">
+                  Wireless Headphone
+                  <span class="absolute inset-0" aria-hidden="true"></span>
+                </a>
+              </p>
+            </div>
+          </div>
+
+          <div class="relative transition-all duration-300 bg-gray-100 rounded-xl hover:shadow-xl hover:bg-white">
+            <div class="px-4 py-5 sm:p-6">
+              <img class="object-cover w-24 h-24 mx-auto border border-gray-200 rounded-full" src="https://cdn.rareblocks.xyz/collection/clarity-ecommerce/images/categories/2/smart-phones.png" alt="">
+              <p class="mt-5 text-base font-bold text-gray-900">
+                <a href="#" title="">
+                  Smart <br class="block sm:hidden xl:block">Phones
+                  <span class="absolute inset-0" aria-hidden="true"></span>
+                </a>
+              </p>
+            </div>
+          </div>
+
+          <div class="relative transition-all duration-300 bg-gray-100 rounded-xl hover:shadow-xl hover:bg-white">
+            <div class="px-4 py-5 sm:p-6">
+              <img class="object-cover w-24 h-24 mx-auto border border-gray-200 rounded-full" src="https://cdn.rareblocks.xyz/collection/clarity-ecommerce/images/categories/2/runnies-shoes.png" alt="">
+              <p class="mt-5 text-base font-bold text-gray-900">
+                <a href="#" title="">
+                  Running Shoes
+                  <span class="absolute inset-0" aria-hidden="true"></span>
+                </a>
+              </p>
+            </div>
+          </div>
+
+          <div class="relative transition-all duration-300 bg-gray-100 rounded-xl hover:shadow-xl hover:bg-white">
+            <div class="px-4 py-5 sm:p-6">
+              <img class="object-cover w-24 h-24 mx-auto border border-gray-200 rounded-full" src="https://cdn.rareblocks.xyz/collection/clarity-ecommerce/images/categories/2/leather-items.png" alt="">
+              <p class="mt-5 text-base font-bold text-gray-900">
+                <a href="#" title="">
+                  Leather Items
+                  <span class="absolute inset-0" aria-hidden="true"></span>
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="block mt-8 text-center md:hidden">
+          <a href="#" title="" class="inline-flex items-center p-1 -m-1 text-xs font-bold tracking-wide text-gray-400 uppercase transition-all duration-200 rounded hover:text-gray-900 focus:ring-2 focus:text-gray-900 focus:ring-gray-900 focus:ring-offset-2 focus:outline-none" role="button">
+            All Categories
+            <svg class="w-4 h-4 ml-1.5 -mt-0.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+            </svg>
+          </a>
+        </div>
+      </div>
+    </section>
 
 		<div class="category-filters py-6 border-b border-gray-200 mb-12">
 			<div class="flex space-x-4 overflow-x-auto pb-4">

--- a/template-parts/content-product-card.php
+++ b/template-parts/content-product-card.php
@@ -1,10 +1,10 @@
 <div class="relative overflow-hidden transition-all duration-300 bg-white border border-gray-100 rounded-lg group hover:shadow-xl">
-    <div class="overflow-hidden aspect-w-4 aspect-h-3">
+    <div class="overflow-hidden aspect-w-1 aspect-h-1">
         <a href="<?php the_permalink(); ?>">
             <?php if (has_post_thumbnail()) : ?>
                 <?php the_post_thumbnail('medium_large', ['class' => 'object-cover w-full h-full transition-all duration-300 group-hover:scale-125']); ?>
             <?php else : ?>
-                <div class="w-full h-full bg-gray-200"></div>
+                <img src="<?php echo get_template_directory_uri(); ?>/assets/images/hero-placeholder.jpg" alt="Default product image" class="object-cover w-full h-full">
             <?php endif; ?>
         </a>
     </div>


### PR DESCRIPTION
This commit introduces a significant visual refresh to the front page of the theme, addressing several of your requests.

- **Hero Section:** Replaces the previous basic hero with a modern, full-width hero section featuring a background image, an overlay, and a restyled, more prominent search form. This provides a more engaging entry point for you.

- **Popular Categories:** Adds a new "Popular Categories" section below the hero, using the specific HTML layout you provided. This section showcases six example categories with images to improve product discovery.

- **Product Cards:** Updates the product card template to enhance visual consistency and your experience:
  - The aspect ratio of product images is now 1:1 (square).
  - A default placeholder image is now displayed for products that do not have a featured image, preventing empty spaces in the layout.