### PR TITLE
feat: Refactor single product page with custom CSS

### DIFF
--- a/assets/css/custom-single-product.css
+++ b/assets/css/custom-single-product.css
@@ -1,0 +1,285 @@
+/* Custom CSS for the Single Product Page */
+
+/* --- General Layout --- */
+.product-page-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: #333;
+}
+
+.product-page-breadcrumbs {
+    margin-bottom: 2rem;
+    font-size: 0.9rem;
+    color: #666;
+}
+
+.product-page-breadcrumbs a {
+    color: #666;
+    text-decoration: none;
+}
+
+.product-page-breadcrumbs a:hover {
+    text-decoration: underline;
+}
+
+.product-page-breadcrumbs span {
+    margin: 0 0.5rem;
+}
+
+.product-page-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2rem;
+}
+
+@media (min-width: 768px) {
+    .product-page-grid {
+        grid-template-columns: 1fr 1fr;
+        gap: 3rem;
+    }
+}
+
+@media (min-width: 1024px) {
+    .product-page-grid {
+        grid-template-columns: 3fr 2fr;
+    }
+}
+
+.section-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    border-bottom: 2px solid #eee;
+    padding-bottom: 0.5rem;
+}
+
+/* --- Product Gallery --- */
+.product-gallery-wrapper {
+    width: 100%;
+}
+
+.gallery-top {
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.gallery-thumbs {
+    margin-top: 1rem;
+}
+
+.gallery-thumbs .swiper-slide {
+    cursor: pointer;
+    border: 2px solid transparent;
+    border-radius: 4px;
+    overflow: hidden;
+    opacity: 0.6;
+    transition: opacity 0.3s ease, border-color 0.3s ease;
+}
+
+.gallery-thumbs .swiper-slide:hover {
+    opacity: 1;
+}
+
+.gallery-thumbs .swiper-slide-thumb-active {
+    opacity: 1;
+    border-color: #007bff;
+}
+
+.product-gallery-main-image,
+.product-gallery-placeholder {
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.product-gallery-main-image img,
+.product-gallery-placeholder img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+/* --- Product Details --- */
+.product-details-wrapper {
+    display: flex;
+    flex-direction: column;
+}
+
+.product-title {
+    font-size: 2rem;
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 1rem;
+}
+
+.product-price {
+    font-size: 1.75rem;
+    font-weight: 300;
+    color: #007bff;
+    margin-bottom: 1.5rem;
+}
+
+.product-description {
+    margin-bottom: 1.5rem;
+}
+
+.product-meta {
+    margin-bottom: 1.5rem;
+}
+
+.product-meta-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.product-meta-list li {
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #eee;
+}
+
+.product-meta-list li:last-child {
+    border-bottom: none;
+}
+
+.product-meta-list strong {
+    font-weight: 600;
+    margin-right: 0.5rem;
+}
+
+.product-meta-list a {
+    color: #007bff;
+    text-decoration: none;
+}
+
+.product-meta-list a:hover {
+    text-decoration: underline;
+}
+
+/* --- Buttons & Actions --- */
+.btn {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    text-align: center;
+    text-decoration: none;
+    border-radius: 4px;
+    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+    cursor: pointer;
+}
+
+.btn-primary {
+    background-color: #007bff;
+    color: #fff;
+    border: 1px solid #007bff;
+}
+
+.btn-primary:hover {
+    background-color: #0056b3;
+}
+
+.btn-secondary {
+    background-color: #6c757d;
+    color: #fff;
+    border: 1px solid #6c757d;
+}
+
+.btn-secondary:hover {
+    background-color: #5a6268;
+}
+
+.btn-full-width {
+    width: 100%;
+}
+
+.product-actions {
+    margin-bottom: 1.5rem;
+}
+
+/* --- Seller Info --- */
+.seller-info-box {
+    background-color: #f8f9fa;
+    padding: 1.5rem;
+    border-radius: 8px;
+    margin-top: auto; /* Pushes to the bottom */
+}
+
+.seller-info-content {
+    display: flex;
+    align-items: center;
+}
+
+.seller-avatar {
+    margin-right: 1rem;
+}
+
+.seller-avatar img {
+    border-radius: 50%;
+}
+
+.seller-details .seller-name {
+    font-weight: 600;
+    margin: 0 0 0.25rem;
+}
+
+.seller-details .seller-link {
+    font-size: 0.9rem;
+    color: #007bff;
+    text-decoration: none;
+}
+
+.seller-details .seller-link:hover {
+    text-decoration: underline;
+}
+
+.seller-details .edit-product-link {
+    margin-top: 0.5rem;
+    font-size: 0.8rem;
+    padding: 0.25rem 0.75rem;
+}
+
+
+/* --- Contact Form --- */
+.contact-seller-section {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid #eee;
+}
+
+.contact-seller-wrapper {
+    max-width: 600px;
+    margin: 0 auto;
+    background-color: #fff;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+}
+
+.form-group {
+    margin-bottom: 1rem;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+}
+
+.form-control {
+    width: 100%;
+    padding: 0.75rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 1rem;
+}
+
+.form-note {
+    text-align: center;
+    font-size: 0.8rem;
+    color: #666;
+    margin-top: 1rem;
+}

--- a/functions.php
+++ b/functions.php
@@ -119,6 +119,7 @@ function shecy_scripts() {
 
 	if ( is_singular( 'shecy_product' ) ) {
 		wp_enqueue_script( 'product-gallery', get_template_directory_uri() . '/assets/js/product-gallery.js', array( 'swiper' ), SHECY_VERSION, true );
+		wp_enqueue_style( 'custom-single-product', get_template_directory_uri() . '/assets/css/custom-single-product.css', array(), SHECY_VERSION );
 	}
 
 	if ( is_front_page() ) {

--- a/single-shecy_product.php
+++ b/single-shecy_product.php
@@ -12,193 +12,146 @@ get_header();
 
 <main id="primary" class="site-main">
     <?php while ( have_posts() ) : the_post(); ?>
-    <section class="py-12 bg-gray-50 sm:py-16">
-        <div class="px-4 mx-auto sm:px-6 lg:px-8 max-w-7xl">
-            <nav class="flex">
-                <ol role="list" class="flex items-center space-x-0.5">
-                    <li>
-                        <div class="-m-1">
-                            <a href="<?php echo esc_url( home_url( '/' ) ); ?>" class="p-1 text-sm font-medium text-gray-500 rounded-md focus:outline-none focus:ring-2 focus:text-gray-900 focus:ring-gray-900 hover:text-gray-700">
-                                Home
-                            </a>
-                        </div>
-                    </li>
-                    <li>
-                        <div class="flex items-center">
-                            <svg class="flex-shrink-0 w-5 h-5 text-gray-300" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z"></path></svg>
-                            <a href="<?php echo get_post_type_archive_link('shecy_product'); ?>" class="p-1 ml-0.5 text-sm font-medium text-gray-500 rounded-md focus:outline-none focus:ring-2 focus:text-gray-900 focus:ring-gray-900 hover:text-gray-700">
-                                Products
-                            </a>
-                        </div>
-                    </li>
-                    <li>
-                        <div class="flex items-center">
-                            <svg class="flex-shrink-0 w-5 h-5 text-gray-300" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z"></path></svg>
-                            <a href="<?php the_permalink(); ?>" class="p-1 ml-0.5 text-sm font-medium text-gray-500 rounded-md focus:outline-none focus:ring-2 focus:text-gray-900 focus:ring-gray-900 hover:text-gray-700" aria-current="page">
-                                <?php the_title(); ?>
-                            </a>
-                        </div>
-                    </li>
-                </ol>
-            </nav>
+    <div class="product-page-container">
 
-            <div class="grid grid-cols-1 mt-8 lg:grid-rows-1 gap-y-12 lg:mt-12 lg:grid-cols-5 lg:gap-y-16 lg:gap-x-12 xl:gap-x-16">
-                <div class="lg:col-span-3 lg:row-end-1">
-                    <div class="product-images">
-						<?php
-						$gallery_ids = get_post_meta( get_the_ID(), 'product_gallery_ids', true );
-						if ( ! empty( $gallery_ids ) ) :
-						?>
-							<!-- Swiper -->
-							<div style="--swiper-navigation-color: #fff; --swiper-pagination-color: #fff" class="swiper gallery-top mb-4 rounded-lg shadow-lg overflow-hidden">
-								<div class="swiper-wrapper">
-									<?php foreach ( $gallery_ids as $attachment_id ) : ?>
-										<div class="swiper-slide">
-											<a href="<?php echo wp_get_attachment_url( $attachment_id ); ?>" data-fancybox="product-gallery">
-												<?php echo wp_get_attachment_image( $attachment_id, 'large', false, ['class' => 'w-full h-auto'] ); ?>
-											</a>
-										</div>
-									<?php endforeach; ?>
-								</div>
-								<!-- Add Arrows -->
-								<div class="swiper-button-next"></div>
-								<div class="swiper-button-prev"></div>
-							</div>
-							<div class="swiper gallery-thumbs h-24">
-								<div class="swiper-wrapper">
-									<?php foreach ( $gallery_ids as $attachment_id ) : ?>
-										<div class="swiper-slide cursor-pointer rounded-lg overflow-hidden">
-											<?php echo wp_get_attachment_image( $attachment_id, 'thumbnail', false, ['class' => 'w-full h-full object-cover'] ); ?>
-										</div>
-									<?php endforeach; ?>
-								</div>
-							</div>
-						<?php elseif ( has_post_thumbnail() ) : ?>
-							<div class="w-full h-auto rounded-lg shadow-lg overflow-hidden">
-								<a href="<?php the_post_thumbnail_url('large'); ?>" data-fancybox="product-gallery">
-									<?php the_post_thumbnail( 'large' ); ?>
-								</a>
-							</div>
-						<?php else : ?>
-							<div class="w-full h-96 bg-gray-200 flex items-center justify-center rounded-lg">
-                                <img class="object-cover w-full h-full" src="<?php echo get_template_directory_uri(); ?>/assets/images/hero-placeholder.jpg" alt="Default product image">
-							</div>
-						<?php endif; ?>
-					</div>
-                </div>
+        <div class="product-page-breadcrumbs">
+            <a href="<?php echo esc_url( home_url( '/' ) ); ?>">Home</a>
+            <span>/</span>
+            <a href="<?php echo get_post_type_archive_link('shecy_product'); ?>">Products</a>
+            <span>/</span>
+            <span><?php the_title(); ?></span>
+        </div>
 
-                <div class="lg:col-span-2 lg:row-end-2 lg:row-span-2">
-                    <h1 class="text-2xl font-bold text-gray-900 sm:text-3xl">
-                        <?php the_title(); ?>
-                    </h1>
-
-                    <?php
-                    $price = get_post_meta( get_the_ID(), 'product_price', true );
-                    if ( $price ) : ?>
-                    <div class="flex items-center mt-8">
-                        <p class="text-3xl font-bold text-gray-900">
-                            $<?php echo esc_html($price); ?>
-                        </p>
+        <div class="product-page-grid">
+            <div class="product-gallery-wrapper">
+                <?php
+                $gallery_ids = get_post_meta( get_the_ID(), 'product_gallery_ids', true );
+                if ( ! empty( $gallery_ids ) ) :
+                ?>
+                    <!-- Swiper -->
+                    <div style="--swiper-navigation-color: #333; --swiper-pagination-color: #333" class="swiper gallery-top">
+                        <div class="swiper-wrapper">
+                            <?php foreach ( $gallery_ids as $attachment_id ) : ?>
+                                <div class="swiper-slide">
+                                    <a href="<?php echo wp_get_attachment_url( $attachment_id ); ?>" data-fancybox="product-gallery">
+                                        <?php echo wp_get_attachment_image( $attachment_id, 'large' ); ?>
+                                    </a>
+                                </div>
+                            <?php endforeach; ?>
+                        </div>
+                        <div class="swiper-button-next"></div>
+                        <div class="swiper-button-prev"></div>
                     </div>
-                    <?php endif; ?>
-
-                    <div class="mt-8">
-                        <h2 class="text-base font-bold text-gray-900">Description</h2>
-                        <div class="mt-4 prose">
-                            <?php the_content(); ?>
+                    <div class="swiper gallery-thumbs">
+                        <div class="swiper-wrapper">
+                            <?php foreach ( $gallery_ids as $attachment_id ) : ?>
+                                <div class="swiper-slide">
+                                    <?php echo wp_get_attachment_image( $attachment_id, 'thumbnail' ); ?>
+                                </div>
+                            <?php endforeach; ?>
                         </div>
                     </div>
-
-                    <div class="product-meta border-t border-b border-gray-200 py-4 my-6">
-                        <h2 class="text-base font-bold text-gray-900 mb-4">Product Details</h2>
-                        <div class="grid grid-cols-2 gap-4 text-sm">
-                            <?php
-                            // Categories
-                            $categories = get_the_terms( get_the_ID(), 'shecy_product_category' );
-                            if ( $categories && ! is_wp_error( $categories ) ) {
-                                echo '<div><strong>Category:</strong></div>';
-                                $cat_links = array();
-                                foreach ( $categories as $category ) {
-                                    $cat_links[] = '<a href="' . get_term_link( $category ) . '" class="text-violet-500 hover:underline">' . esc_html( $category->name ) . '</a>';
-                                }
-                                echo '<div>' . implode( ', ', $cat_links ) . '</div>';
-                            }
-
-                            // Condition
-                            $condition = get_post_meta( get_the_ID(), 'product_condition', true );
-                            if ( $condition ) {
-                                echo '<div><strong>Condition:</strong></div>';
-                                echo '<div>' . esc_html( ucwords( str_replace( '_', ' ', $condition ) ) ) . '</div>';
-                            }
-
-                            // Brand
-                            $brand = get_post_meta( get_the_ID(), 'product_brand', true );
-                            if ( $brand ) {
-                                echo '<div><strong>Brand:</strong></div>';
-                                echo '<div>' . esc_html( $brand ) . '</div>';
-                            }
-
-                            // Location
-                            $location = get_post_meta( get_the_ID(), 'product_location', true );
-                            if ( $location ) {
-                                echo '<div><strong>Location:</strong></div>';
-                                echo '<div>' . esc_html( $location ) . '</div>';
-                            }
-                            ?>
-                        </div>
-                    </div>
-
-                    <div class="flex items-center mt-10 space-x-4">
-                        <a href="#contact-seller-form" class="inline-flex items-center justify-center px-12 py-3 text-base font-bold leading-7 text-white transition-all duration-200 bg-gray-900 border-2 border-transparent rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900 hover:bg-gray-700">
-                            Contact Seller
+                <?php elseif ( has_post_thumbnail() ) : ?>
+                    <div class="product-gallery-main-image">
+                        <a href="<?php the_post_thumbnail_url('large'); ?>" data-fancybox="product-gallery">
+                            <?php the_post_thumbnail( 'large' ); ?>
                         </a>
                     </div>
+                <?php else : ?>
+                    <div class="product-gallery-placeholder">
+                        <img src="<?php echo get_template_directory_uri(); ?>/assets/images/hero-placeholder.jpg" alt="Default product image">
+                    </div>
+                <?php endif; ?>
+            </div>
 
-                    <div class="mt-8 border-t pt-8">
-                        <h3 class="text-xl font-bold mb-4">Seller Information</h3>
-                        <div class="flex items-center">
-                            <div class="mr-4">
-                                <?php echo get_avatar( get_the_author_meta( 'ID' ), 64, '', '', ['class' => 'rounded-full'] ); ?>
-                            </div>
-                            <div>
-                                <p class="font-bold"><?php the_author(); ?></p>
-                                <a href="<?php echo get_author_posts_url( get_the_author_meta( 'ID' ) ); ?>" class="text-violet-500 hover:underline">View all products from this seller</a>
-                                <?php if ( get_current_user_id() == $post->post_author ) : ?>
-                                    <a href="<?php echo home_url('/edit-product?product_id=' . get_the_ID()); ?>" class="mt-2 inline-block bg-violet-500 text-white hover:bg-violet-600 py-1 px-3 rounded-md text-xs font-medium">Edit Product</a>
-                                <?php endif; ?>
-                            </div>
+            <div class="product-details-wrapper">
+                <h1 class="product-title"><?php the_title(); ?></h1>
+
+                <?php
+                $price = get_post_meta( get_the_ID(), 'product_price', true );
+                if ( $price ) : ?>
+                <p class="product-price">$<?php echo esc_html($price); ?></p>
+                <?php endif; ?>
+
+                <div class="product-description">
+                    <h2 class="section-title">Description</h2>
+                    <?php the_content(); ?>
+                </div>
+
+                <div class="product-meta">
+                    <h2 class="section-title">Product Details</h2>
+                    <ul class="product-meta-list">
+                        <?php
+                        $categories = get_the_terms( get_the_ID(), 'shecy_product_category' );
+                        if ( $categories && ! is_wp_error( $categories ) ) {
+                            echo '<li><strong>Category:</strong> ';
+                            $cat_links = array();
+                            foreach ( $categories as $category ) {
+                                $cat_links[] = '<a href="' . get_term_link( $category ) . '">' . esc_html( $category->name ) . '</a>';
+                            }
+                            echo implode( ', ', $cat_links ) . '</li>';
+                        }
+                        $condition = get_post_meta( get_the_ID(), 'product_condition', true );
+                        if ( $condition ) {
+                            echo '<li><strong>Condition:</strong> ' . esc_html( ucwords( str_replace( '_', ' ', $condition ) ) ) . '</li>';
+                        }
+                        $brand = get_post_meta( get_the_ID(), 'product_brand', true );
+                        if ( $brand ) {
+                            echo '<li><strong>Brand:</strong> ' . esc_html( $brand ) . '</li>';
+                        }
+                        $location = get_post_meta( get_the_ID(), 'product_location', true );
+                        if ( $location ) {
+                            echo '<li><strong>Location:</strong> ' . esc_html( $location ) . '</li>';
+                        }
+                        ?>
+                    </ul>
+                </div>
+
+                <div class="product-actions">
+                    <a href="#contact-seller-form" class="btn btn-primary">Contact Seller</a>
+                </div>
+
+                <div class="seller-info-box">
+                    <h2 class="section-title">Seller Information</h2>
+                    <div class="seller-info-content">
+                        <div class="seller-avatar">
+                            <?php echo get_avatar( get_the_author_meta( 'ID' ), 80 ); ?>
+                        </div>
+                        <div class="seller-details">
+                            <p class="seller-name"><?php the_author(); ?></p>
+                            <a href="<?php echo get_author_posts_url( get_the_author_meta( 'ID' ) ); ?>" class="seller-link">View all products</a>
+                            <?php if ( get_current_user_id() == $post->post_author ) : ?>
+                                <a href="<?php echo home_url('/edit-product?product_id=' . get_the_ID()); ?>" class="btn btn-secondary edit-product-link">Edit Product</a>
+                            <?php endif; ?>
                         </div>
                     </div>
-
                 </div>
             </div>
-
-            <div id="contact-seller-form" class="mt-12 max-w-lg mx-auto">
-                <div class="contact-seller p-6 bg-white rounded-lg shadow-md">
-                    <h3 class="text-xl font-bold mb-4">Contact Seller</h3>
-                    <form class="space-y-4">
-                        <div>
-                            <label for="contact-name" class="block text-sm font-medium text-gray-700">Your Name</label>
-                            <input type="text" name="contact-name" id="contact-name" class="mt-1 block w-full py-2 px-3 border border-gray-300 rounded-md shadow-sm focus:ring-violet-500 focus:border-violet-500">
-                        </div>
-                        <div>
-                            <label for="contact-email" class="block text-sm font-medium text-gray-700">Your Email</label>
-                            <input type="email" name="contact-email" id="contact-email" class="mt-1 block w-full py-2 px-3 border border-gray-300 rounded-md shadow-sm focus:ring-violet-500 focus:border-violet-500">
-                        </div>
-                        <div>
-                            <label for="contact-message" class="block text-sm font-medium text-gray-700">Message</label>
-                            <textarea name="contact-message" id="contact-message" rows="4" class="mt-1 block w-full py-2 px-3 border border-gray-300 rounded-md shadow-sm focus:ring-violet-500 focus:border-violet-500"></textarea>
-                        </div>
-                        <div>
-                            <button type="submit" class="w-full inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-violet-500 hover:bg-violet-600">Send Message</button>
-                            <p class="text-xs text-gray-500 mt-2 text-center">(Note: Form is for display only and not functional yet)</p>
-                        </div>
-                    </form>
-                </div>
-            </div>
-
         </div>
-    </section>
+
+        <div id="contact-seller-form" class="contact-seller-section">
+            <div class="contact-seller-wrapper">
+                <h2 class="section-title">Contact Seller</h2>
+                <form class="contact-form">
+                    <div class="form-group">
+                        <label for="contact-name">Your Name</label>
+                        <input type="text" name="contact-name" id="contact-name" class="form-control">
+                    </div>
+                    <div class="form-group">
+                        <label for="contact-email">Your Email</label>
+                        <input type="email" name="contact-email" id="contact-email" class="form-control">
+                    </div>
+                    <div class="form-group">
+                        <label for="contact-message">Message</label>
+                        <textarea name="contact-message" id="contact-message" rows="4" class="form-control"></textarea>
+                    </div>
+                    <button type="submit" class="btn btn-primary btn-full-width">Send Message</button>
+                    <p class="form-note">(Note: Form is for display only and not functional yet)</p>
+                </form>
+            </div>
+        </div>
+
+    </div>
     <?php endwhile; ?>
 </main>
 


### PR DESCRIPTION
This commit refactors the single product page to use a custom stylesheet instead of Tailwind CSS utility classes, as you requested. This change improves the separation of concerns and allows for a more unique and creative design.

- Created a new stylesheet at `assets/css/custom-single-product.css`.
- Enqueued the new stylesheet in `functions.php` to be loaded only on single product pages.
- Replaced the entire `single-shecy_product.php` template with a new HTML structure using semantic, BEM-like class names.
- Implemented a new, creative, and responsive design for the product page using custom CSS.
- Ensured all dynamic data, including the Swiper.js gallery, product details, and seller information, is preserved and correctly displayed in the new layout.